### PR TITLE
Request for small correction of the memory test

### DIFF
--- a/src/test/java/com/make/my/day/hm5/MergeSortJoinTest.java
+++ b/src/test/java/com/make/my/day/hm5/MergeSortJoinTest.java
@@ -99,7 +99,7 @@ public class MergeSortJoinTest {
         long count = StreamSupport.stream(new MergeSortInnerJoinSpliterator<>(left,
                 right, Function.identity(), Function.identity(), true), false)
                 .count();
-        assertThat("Incorrect result", count, is(Integer.MAX_VALUE >> 2));
+        assertThat("Incorrect result", count, is((long)Integer.MAX_VALUE >> 2));
     }
 
     //ToDo: Implement your own merge sort inner join spliterator. See https://en.wikipedia.org/wiki/Sort-merge_join


### PR DESCRIPTION
On my currect not-so-working version of spliterator I get this
java.lang.AssertionError: Incorrect result
Expected: is <536870911>
     but: was <536870911L>

Though numbers are in fact equal, they belong to different types. I suggest expanding expected number to long.